### PR TITLE
Add entity descriptions

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -1,4 +1,11 @@
-﻿[entity-description]
+[entity-description]
+duct-small=Small section of high-throughput pipeline with two connection points.
+duct=Section of high-throughput pipeline with two connection points.
+duct-long=Long section of high-throughput pipeline with two connection points.
+duct-t-junction=Section of high-throughput pipeline with three junctions.
+duct-curve=Curved section of high-throughput pipeline.
+duct-cross=Section of high-throughput pipeline with four connection points.
+duct-underground=Underground section of high-throughput pipeline.
 duct-end-point-intake=Transfers fluids from normal pipes into a duct.
 duct-end-point-outtake=Transfers fluids from a duct into normal pipes.
 non-return-duct=Forces fluids to flow in a single direction.


### PR DESCRIPTION
I'm wondering if adding these entity descriptions will fix the "Unknown key:" issue in the Space Exploration mod?

![image](https://user-images.githubusercontent.com/2053960/227718628-843088c2-7859-4969-9d9f-b5d160241859.png)
