### PR TITLE
Fix #34, duct/long-duct recipes restored

### DIFF
--- a/prototypes/buildings/duct-long.lua
+++ b/prototypes/buildings/duct-long.lua
@@ -1,20 +1,15 @@
 local constants = require("prototypes.constants")
 
-if not settings.startup["fmf-enable-duct-auto-join"].value then
-  data:extend({
-    {
-      type = "recipe",
-      name = "duct-long",
-      enabled = false,
-      category = "crafting",
-      energy_required = 2.0,
-      ingredients = { { type = "item", name = "iron-plate", amount = 16 } },
-      results = { { type = "item", name = "duct-long", amount = 1 } },
-    },
-  })
-end
-
 data:extend({
+  {
+    type = "recipe",
+    name = "duct-long",
+    enabled = false,
+    category = "crafting",
+    energy_required = 2.0,
+    ingredients = { { type = "item", name = "iron-plate", amount = 16 } },
+    results = { { type = "item", name = "duct-long", amount = 1 } },
+  },
   {
     type = "item",
     name = "duct-long",

--- a/prototypes/buildings/duct.lua
+++ b/prototypes/buildings/duct.lua
@@ -1,20 +1,15 @@
 local constants = require("prototypes.constants")
 
-if not settings.startup["fmf-enable-duct-auto-join"].value then
-  data:extend({
-    {
-      type = "recipe",
-      name = "duct",
-      enabled = false,
-      category = "crafting",
-      energy_required = 2.0,
-      ingredients = { { type = "item", name = "iron-plate", amount = 8 } },
-      results = { { type = "item", name = "duct", amount = 1 } },
-    },
-  })
-end
-
 data:extend({
+  {
+    type = "recipe",
+    name = "duct",
+    enabled = false,
+    category = "crafting",
+    energy_required = 2.0,
+    ingredients = { { type = "item", name = "iron-plate", amount = 8 } },
+    results = { { type = "item", name = "duct", amount = 1 } },
+  },
   {
     type = "item",
     name = "duct",

--- a/prototypes/technologies.lua
+++ b/prototypes/technologies.lua
@@ -5,6 +5,14 @@ local effects = {
   },
   {
     type = "unlock-recipe",
+    recipe = "duct",
+  },
+  {
+    type = "unlock-recipe",
+    recipe = "duct-long",
+  },
+  {
+    type = "unlock-recipe",
     recipe = "duct-t-junction",
   },
   {
@@ -33,16 +41,6 @@ local effects = {
   },
 }
 
-if not settings.startup["fmf-enable-duct-auto-join"].value then
-  table.insert(effects, {
-    type = "unlock-recipe",
-    recipe = "duct",
-  })
-  table.insert(effects, {
-    type = "unlock-recipe",
-    recipe = "duct-long",
-  })
-end
 
 --- Gets the first technology that unlocks the given recipe
 --- @param recipe_name string


### PR DESCRIPTION
Fix for https://github.com/raiguard/FluidMustFlow/issues/34

Tested auto-join and it still works.
Tested a new game with and without auto-join.